### PR TITLE
Fix compilation errors with newer GCC versions

### DIFF
--- a/exynos/multimedia/openmax/component/audio/dec/SEC_OMX_Adec.h
+++ b/exynos/multimedia/openmax/component/audio/dec/SEC_OMX_Adec.h
@@ -123,7 +123,7 @@ OMX_ERRORTYPE SEC_OMX_AudioDecodeGetExtensionIndex(
 OMX_ERRORTYPE SEC_OMX_AudioDecodeComponentInit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_ERRORTYPE SEC_OMX_AudioDecodeComponentDeinit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_BOOL SEC_Check_BufferProcess_State(SEC_OMX_BASECOMPONENT *pSECComponent);
-inline void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
+void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
 
 #ifdef __cplusplus
 }

--- a/exynos/multimedia/openmax/component/video/dec/Android.mk
+++ b/exynos/multimedia/openmax/component/video/dec/Android.mk
@@ -12,6 +12,7 @@ LOCAL_C_INCLUDES := $(OMX_INC) \
 	$(SEC_OMX_INC)/sec \
 	$(SEC_OMX_TOP)/osal \
 	$(SEC_OMX_TOP)/core \
+	$(SEC_OMX_TOP)/include/sec \
 	$(SEC_OMX_COMPONENT)/common \
 	$(SEC_OMX_COMPONENT)/video/dec
 

--- a/exynos/multimedia/openmax/component/video/dec/SEC_OMX_Vdec.c
+++ b/exynos/multimedia/openmax/component/video/dec/SEC_OMX_Vdec.c
@@ -48,7 +48,7 @@
 #include "SEC_OSAL_Log.h"
 
 
-inline void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent)
+void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent)
 {
     SEC_OMX_BASECOMPONENT *pSECComponent = (SEC_OMX_BASECOMPONENT *)pOMXComponent->pComponentPrivate;
     SEC_OMX_BASEPORT      *secInputPort = &pSECComponent->pSECPort[INPUT_PORT_INDEX];

--- a/exynos/multimedia/openmax/component/video/dec/SEC_OMX_Vdec.h
+++ b/exynos/multimedia/openmax/component/video/dec/SEC_OMX_Vdec.h
@@ -144,7 +144,7 @@ OMX_ERRORTYPE SEC_OMX_VideoDecodeGetExtensionIndex(
 OMX_ERRORTYPE SEC_OMX_VideoDecodeComponentInit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_ERRORTYPE SEC_OMX_VideoDecodeComponentDeinit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_BOOL SEC_Check_BufferProcess_State(SEC_OMX_BASECOMPONENT *pSECComponent);
-inline void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
+void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
 
 #ifdef __cplusplus
 }

--- a/exynos/multimedia/openmax/component/video/enc/Android.mk
+++ b/exynos/multimedia/openmax/component/video/enc/Android.mk
@@ -12,6 +12,7 @@ LOCAL_C_INCLUDES := $(OMX_INC) \
 	$(SEC_OMX_INC)/sec \
 	$(SEC_OMX_TOP)/osal \
 	$(SEC_OMX_TOP)/core \
+	$(SEC_OMX_TOP)/include/sec \
 	$(SEC_OMX_COMPONENT)/common \
 	$(SEC_OMX_COMPONENT)/video/dec \
 	$(TARGET_OUT_HEADERS)/$(SEC_COPY_HEADERS_TO)

--- a/exynos/multimedia/openmax/component/video/enc/SEC_OMX_Venc.c
+++ b/exynos/multimedia/openmax/component/video/enc/SEC_OMX_Venc.c
@@ -48,7 +48,7 @@
 #include "SEC_OSAL_Log.h"
 
 
-inline void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent)
+void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent)
 {
     SEC_OMX_BASECOMPONENT *pSECComponent = (SEC_OMX_BASECOMPONENT *)pOMXComponent->pComponentPrivate;
     SEC_OMX_BASEPORT      *secInputPort = &pSECComponent->pSECPort[INPUT_PORT_INDEX];

--- a/exynos/multimedia/openmax/component/video/enc/SEC_OMX_Venc.h
+++ b/exynos/multimedia/openmax/component/video/enc/SEC_OMX_Venc.h
@@ -155,7 +155,7 @@ OMX_ERRORTYPE SEC_OMX_VideoEncodeGetExtensionIndex(
 OMX_ERRORTYPE SEC_OMX_VideoEncodeComponentInit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_ERRORTYPE SEC_OMX_VideoEncodeComponentDeinit(OMX_IN OMX_HANDLETYPE hComponent);
 OMX_BOOL SEC_Check_BufferProcess_State(SEC_OMX_BASECOMPONENT *pSECComponent);
-inline void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
+void SEC_UpdateFrameSize(OMX_COMPONENTTYPE *pOMXComponent);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Why are those inline'ed?

Signed-off-by: arter97 qkrwngud825@gmail.com
