### PR TITLE
Switch FIMC1 and ION

### DIFF
--- a/exynos/multimedia/openmax/component/video/dec/h264/SEC_OMX_H264dec.c
+++ b/exynos/multimedia/openmax/component/video/dec/h264/SEC_OMX_H264dec.c
@@ -45,7 +45,7 @@
 #endif
 
 /* To use CSC FIMC in SEC OMX, gralloc should allocate physical memory using FIMC */
-/* It means GRALLOC_USAGE_HW_FIMC1 should be set on Native Window usage */
+/* It means GRALLOC_USAGE_HW_ION should be set on Native Window usage */
 #ifdef USE_CSC_FIMC
 #include "csc_fimc.h"
 #endif

--- a/exynos/multimedia/openmax/component/video/dec/mpeg4/SEC_OMX_Mpeg4dec.c
+++ b/exynos/multimedia/openmax/component/video/dec/mpeg4/SEC_OMX_Mpeg4dec.c
@@ -45,7 +45,7 @@
 #endif
 
 /* To use CSC FIMC in SEC OMX, gralloc should allocate physical memory using FIMC */
-/* It means GRALLOC_USAGE_HW_FIMC1 should be set on Native Window usage */
+/* It means GRALLOC_USAGE_HW_ION should be set on Native Window usage */
 #ifdef USE_CSC_FIMC
 #include "csc_fimc.h"
 #endif

--- a/exynos/multimedia/openmax/component/video/dec/vc1/SEC_OMX_Wmvdec.c
+++ b/exynos/multimedia/openmax/component/video/dec/vc1/SEC_OMX_Wmvdec.c
@@ -49,7 +49,7 @@
 #endif
 
 /* To use CSC FIMC in SEC OMX, gralloc should allocate physical memory using FIMC */
-/* It means GRALLOC_USAGE_HW_FIMC1 should be set on Native Window usage */
+/* It means GRALLOC_USAGE_HW_ION should be set on Native Window usage */
 #ifdef USE_CSC_FIMC
 #include "csc_fimc.h"
 #endif

--- a/exynos4/hal/libgralloc_ump/alloc_device.cpp
+++ b/exynos4/hal/libgralloc_ump/alloc_device.cpp
@@ -114,8 +114,8 @@ static int gralloc_alloc_buffer(alloc_device_t* dev, size_t size, int usage,
 
     size = round_up_to_page_size(size);
 
-    if (usage & GRALLOC_USAGE_HW_ION) {
-        ALOGD_IF(debug_level > 0, "%s usage = GRALLOC_USAGE_HW_ION", __func__);
+    if (usage & GRALLOC_USAGE_HW_FIMC1) {
+        ALOGD_IF(debug_level > 0, "%s usage = GRALLOC_USAGE_HW_FIMC1", __func__);
 
         char node[20];
         int ret;
@@ -192,7 +192,7 @@ static int gralloc_alloc_buffer(alloc_device_t* dev, size_t size, int usage,
 
         current_address = gReservedMemAddr + buffer_offset;
 
-        if ( (usage < 0 || usage & (GRALLOC_USAGE_HWC_HWOVERLAY | GRALLOC_USAGE_HW_ION)) &&
+        if ( (usage < 0 || usage & (GRALLOC_USAGE_HWC_HWOVERLAY | GRALLOC_USAGE_HW_FIMC1)) &&
              (format == (int)HAL_PIXEL_FORMAT_RGBA_8888 || format == (int)HAL_PIXEL_FORMAT_RGB_565) ) {
 
             if (usage & GRALLOC_USAGE_PRIVATE_NONECACHE) {
@@ -234,8 +234,8 @@ static int gralloc_alloc_buffer(alloc_device_t* dev, size_t size, int usage,
         return 0;
     }
 
-    if (usage & GRALLOC_USAGE_HW_FIMC1) {
-        ALOGD_IF(debug_level > 0, "%s usage = GRALLOC_USAGE_HW_FIMC1", __func__);
+    if (usage & GRALLOC_USAGE_HW_ION) {
+        ALOGD_IF(debug_level > 0, "%s usage = GRALLOC_USAGE_HW_ION", __func__);
 
         if (!ion_dev_open) {
             ALOGE("%s ERROR, failed to open ion", __func__);
@@ -503,26 +503,26 @@ static int alloc_device_alloc(alloc_device_t* dev, int w, int h, int format,
             // 0x107 = HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED (Samsung-specific pixel format)
 
             /* We need at least 0x1802930 for playing video */
-            if (!(l_usage & GRALLOC_USAGE_HW_FIMC1)) {
-                l_usage |= GRALLOC_USAGE_HW_FIMC1; // Exynos HWC wants FIMC-friendly memory allocation
-                ALOGD("%s added usage GRALLOC_USAGE_HW_FIMC1 because of format\n", __func__);
+            if (!(l_usage & GRALLOC_USAGE_HW_ION)) {
+                l_usage |= GRALLOC_USAGE_HW_ION; // Exynos HWC wants ION-friendly memory allocation
+                ALOGD("%s added usage GRALLOC_USAGE_HW_ION because of format\n", __func__);
             }
 
             if (!(l_usage & GRALLOC_USAGE_PRIVATE_NONECACHE)) {
-                l_usage |= GRALLOC_USAGE_PRIVATE_NONECACHE; // Exynos HWC wants FIMC-friendly memory allocation
+                l_usage |= GRALLOC_USAGE_PRIVATE_NONECACHE; // Exynos HWC wants ION-friendly memory allocation
                 ALOGD("%s added usage GRALLOC_USAGE_PRIVATE_NONECACHE because of format\n", __func__);
             }
 
             if (!(l_usage & GRALLOC_USAGE_SW_WRITE_OFTEN)) {
-                l_usage |= GRALLOC_USAGE_SW_WRITE_OFTEN; // Exynos HWC wants FIMC-friendly memory allocation
+                l_usage |= GRALLOC_USAGE_SW_WRITE_OFTEN; // Exynos HWC wants ION-friendly memory allocation
                 ALOGD("%s added usage GRALLOC_USAGE_SW_WRITE_OFTEN because of format\n", __func__);
             }
         }
 
         switch (format) {
         case HAL_PIXEL_FORMAT_YV12: //0x32315659
-            l_usage |= GRALLOC_USAGE_HW_FIMC1;
-            ALOGD("%s added GRALLOC_USAGE_HW_FIMC1 because of YV12", __func__);
+            l_usage |= GRALLOC_USAGE_HW_ION;
+            ALOGD("%s added GRALLOC_USAGE_HW_ION because of YV12", __func__);
 
         case 0x200:
         case 0x201:
@@ -547,9 +547,9 @@ static int alloc_device_alloc(alloc_device_t* dev, int w, int h, int format,
         case HAL_PIXEL_FORMAT_YCbCr_420_P: //0x101
             //lc_20a4
             size = (stride * vstride) + ((EXYNOS4_ALIGN(w/2,16) * EXYNOS4_ALIGN(h/2,16)) * 2);
-            //stride_raw = l_usage & GRALLOC_USAGE_HW_FIMC1; //It is later overwritten to 0
+            //stride_raw = l_usage & GRALLOC_USAGE_HW_ION; //It is later overwritten to 0
 
-            if (l_usage & GRALLOC_USAGE_HW_FIMC1)
+            if (l_usage & GRALLOC_USAGE_HW_ION)
                 size += (PAGE_SIZE * 2);
 
             break;
@@ -566,7 +566,7 @@ static int alloc_device_alloc(alloc_device_t* dev, int w, int h, int format,
         case OMX_COLOR_FormatYUV420Planar: //0x13
         case OMX_COLOR_FormatYUV420SemiPlanar: //0x15
             size = stride * vstride + EXYNOS4_ALIGN((w / 2), 16) * EXYNOS4_ALIGN((h / 2), 16) * 2;
-            if (l_usage & GRALLOC_USAGE_HW_FIMC1)
+            if (l_usage & GRALLOC_USAGE_HW_ION)
                 size += PAGE_SIZE * 2;
 
             break;

--- a/exynos4/hal/libhwcomposer/SecHWCUtils.cpp
+++ b/exynos4/hal/libhwcomposer/SecHWCUtils.cpp
@@ -659,7 +659,7 @@ static int get_src_phys_addr(struct hwc_context_t *ctx,
     ADDRS * addr;
 
     // error check routine
-    if (0 == src_img->base && !(src_img->usage & GRALLOC_USAGE_HW_FIMC1)) {
+    if (0 == src_img->base && !(src_img->usage & GRALLOC_USAGE_HW_ION)) {
         SEC_HWC_Log(HWC_LOG_ERROR, "%s invalid src image base\n", __func__);
         return 0;
     }
@@ -706,14 +706,14 @@ static int get_src_phys_addr(struct hwc_context_t *ctx,
             }
             break;
         default:
-            if (src_img->usage & GRALLOC_USAGE_HW_FIMC1) {
+            if (src_img->usage & GRALLOC_USAGE_HW_ION) {
                 fimc->params.src.buf_addr_phy_rgb_y = src_img->paddr;
                 fimc->params.src.buf_addr_phy_cb = src_img->paddr + src_img->uoffset;
                 fimc->params.src.buf_addr_phy_cr = src_img->paddr + src_img->uoffset + src_img->voffset;
                 src_phys_addr = fimc->params.src.buf_addr_phy_rgb_y;
             } else {
                 SEC_HWC_Log(HWC_LOG_ERROR, "%s::\nformat = 0x%x : Not "
-                        "GRALLOC_USAGE_HW_FIMC1 can not supported\n",
+                        "GRALLOC_USAGE_HW_ION can not supported\n",
                         __func__, src_img->format);
             }
             break;
@@ -1106,7 +1106,7 @@ static int runFimcCore(struct hwc_context_t *ctx,
             src_cbcr_order = false;
         }
 
-        if (src_img->usage & GRALLOC_USAGE_HW_FIMC1) {
+        if (src_img->usage & GRALLOC_USAGE_HW_ION) {
             fimc_src_buf.base[0] = params->src.buf_addr_phy_rgb_y;
             if (src_cbcr_order == true) {
                 fimc_src_buf.base[1] = params->src.buf_addr_phy_cb;


### PR DESCRIPTION
hardware/samsung/exynos4/hal/libcamera/SecCameraHWInterface.cpp  left intentionally as is, since I think it has the proper meaning

```
#ifdef USE_EGL
#ifdef BOARD_USE_V4L2_ION
    if (w->set_usage(w, GRALLOC_USAGE_SW_WRITE_OFTEN | GRALLOC_USAGE_HW_ION)) {
#else
    if (w->set_usage(w, GRALLOC_USAGE_SW_WRITE_OFTEN)) {
#endif
        ALOGE("%s: could not set usage on gralloc buffer", __func__);
        return INVALID_OPERATION;
    }
#else
#ifdef BOARD_USE_V4L2_ION
    if (w->set_usage(w, GRALLOC_USAGE_SW_WRITE_OFTEN
        | GRALLOC_USAGE_HWC_HWOVERLAY | GRALLOC_USAGE_HW_ION)) {
#else
    if (w->set_usage(w, GRALLOC_USAGE_SW_WRITE_OFTEN
        | GRALLOC_USAGE_HW_FIMC1 | GRALLOC_USAGE_HWC_HWOVERLAY)) {
#endif
        ALOGE("%s: could not set usage on gralloc buffer", __func__);
        return INVALID_OPERATION;
    }
#endif
```

Change-Id: Ieca2c717314bda5ca94a013df3cf8e23d68f74f8
